### PR TITLE
chore: increase frequency to 15 minutes

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -2,7 +2,7 @@ name: Monitor Vulnerabilities
 
 on:
   schedule:
-    - cron: '0 */6 * * *' # Every 6 hours
+    - cron: '*/15 * * * *' # Every 15 minutes
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates the schedule for the vulnerability monitoring workflow to run more frequently.

- CI/CD Workflow Update:
  * [`.github/workflows/monitor.yml`](diffhunk://#diff-46ba6075f63da0cb2a6b89e6834c5335ef0d63563a460a4f938242f0771ef654L5-R5): Changed the vulnerability monitor workflow to run every 15 minutes instead of every 6 hours.