### PR TITLE
chore: update version and use triage

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -27,7 +27,7 @@ jobs:
           cat repos.json >> "$GITHUB_OUTPUT"
           echo "REPOS_EOF" >> "$GITHUB_OUTPUT"
 
-      - uses: spaceraccoon/vulnerability-spoiler-alert-action@26011c0a9923dbc8b56a2f6761388b536ff9e088
+      - uses: spaceraccoon/vulnerability-spoiler-alert-action@b8b1497c76859772898fd210b3f8327b2021d0e4
         with:
           api-key: ${{ secrets.API_KEY }}
           provider: anthropic
@@ -37,6 +37,7 @@ jobs:
           repositories: ${{ steps.repos.outputs.json }}
           enable-repo-context: true
           enable-judge: true
+          triage-model: claude-haiku-4-5
 
       - name: Commit state changes
         run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/monitor.yml` to improve security scanning and triage capabilities. The main changes are an upgrade to the `vulnerability-spoiler-alert-action` and the explicit configuration of the triage model.

**Security scanning and triage improvements:**

* Upgraded the `spaceraccoon/vulnerability-spoiler-alert-action` to commit `b8b1497c76859772898fd210b3f8327b2021d0e4` for improved security scanning features and bug fixes.
* Configured the action to use the `claude-haiku-4-5` model for vulnerability triage, which may enhance the accuracy and efficiency of automated triage.