### PR TITLE
feat: add cve checker

### DIFF
--- a/.github/workflows/cve-check.yml
+++ b/.github/workflows/cve-check.yml
@@ -1,0 +1,30 @@
+name: CVE Match Check
+
+on:
+  schedule:
+    - cron: '0 */6 * * *' # Every 6 hours
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: cve-check
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Match untriaged issues to CVEs
+        run: node scripts/check-cves.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}

--- a/.github/workflows/cve-check.yml
+++ b/.github/workflows/cve-check.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -28,3 +29,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}

--- a/repos.json
+++ b/repos.json
@@ -1,12 +1,55 @@
 [
-  { "owner": "expressjs", "repo": "express" },
-  { "owner": "nodejs", "repo": "node" },
-  { "owner": "django", "repo": "django" },
-  { "owner": "pallets", "repo": "flask" },
-  { "owner": "rails", "repo": "rails" },
-  { "owner": "apache", "repo": "httpd" },
-  { "owner": "nginx", "repo": "nginx" },
-  { "owner": "grafana", "repo": "grafana" },
-  { "owner": "facebook", "repo": "react" },
-  { "owner": "vercel", "repo": "next.js" }
+  {
+    "owner": "expressjs",
+    "repo": "express",
+    "cpes": ["cpe:2.3:a:expressjs:express"]
+  },
+  {
+    "owner": "nodejs",
+    "repo": "node",
+    "cpes": ["cpe:2.3:a:nodejs:node.js"]
+  },
+  {
+    "owner": "django",
+    "repo": "django",
+    "cpes": ["cpe:2.3:a:djangoproject:django"]
+  },
+  {
+    "owner": "pallets",
+    "repo": "flask",
+    "cpes": ["cpe:2.3:a:palletsprojects:flask"]
+  },
+  {
+    "owner": "rails",
+    "repo": "rails",
+    "cpes": ["cpe:2.3:a:rubyonrails:rails"]
+  },
+  {
+    "owner": "apache",
+    "repo": "httpd",
+    "cpes": ["cpe:2.3:a:apache:http_server"]
+  },
+  {
+    "owner": "nginx",
+    "repo": "nginx",
+    "cpes": [
+      "cpe:2.3:a:f5:nginx_open_source",
+      "cpe:2.3:a:f5:nginx_plus"
+    ]
+  },
+  {
+    "owner": "grafana",
+    "repo": "grafana",
+    "cpes": ["cpe:2.3:a:grafana:grafana"]
+  },
+  {
+    "owner": "facebook",
+    "repo": "react",
+    "cpes": ["cpe:2.3:a:facebook:react"]
+  },
+  {
+    "owner": "vercel",
+    "repo": "next.js",
+    "cpes": ["cpe:2.3:a:vercel:next.js"]
+  }
 ]

--- a/scripts/check-cves.mjs
+++ b/scripts/check-cves.mjs
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
-// Checks untriaged vulnerability issues against OSV.dev for matching CVEs.
-// When a commit SHA from an issue matches a known advisory, the script:
-//   1. Adds the `true-positive` label
-//   2. Adds a `cve:<ID>` label (e.g. cve:CVE-2024-12345)
-//   3. Posts a comment summarising the match and the lead time
+// Matches vulnerability issues to CVEs/advisories.
 //
-// Idempotent: skips issues that already carry any `cve:` label.
+// For each candidate issue, first queries OSV.dev by commit SHA. If OSV has no
+// match (common for vendor-coordinated CVEs that reference vendor advisories,
+// not GitHub commits), falls back to NVD filtered by the repo's CPE in a window
+// around the commit date and picks the description-keyword-overlap winner.
+//
+// On a match it adds three labels (`true-positive`, `cve:<ID>`,
+// `cve-published:<YYYY-MM-DD>`) and posts a comment with the lead time.
+//
+// Skips: issues already carrying any `cve:` label (idempotent) and issues
+// labelled `false-positive` (respect manual triage).
 
 import { GITHUB_TOKEN, REPO_OWNER, REPO_NAME, REPO_TO_CPE } from "./lib/config.mjs";
 import { fetchAllIssues } from "./lib/github.mjs";
@@ -47,7 +52,12 @@ function needsCveCheck(issue) {
   return true;
 }
 
-function buildComment(issue, parsed, vuln, advisoryId) {
+const MATCH_SOURCE_LABELS = {
+  "osv-commit": "[OSV.dev](https://osv.dev) commit lookup",
+  "nvd-cpe": "[NVD](https://nvd.nist.gov) CPE + description matching",
+};
+
+function buildComment(issue, parsed, vuln, advisoryId, matchSource, appliedLabels) {
   const leadBase = parsed.date || issue.created_at;
   const lead = vuln.published ? daysBetween(leadBase, vuln.published) : null;
   const summary = vuln.summary || vuln.details?.split("\n")[0] || "(no summary provided)";
@@ -62,15 +72,17 @@ function buildComment(issue, parsed, vuln, advisoryId) {
           : "\n\n**Lead time:** Patch landed the same day the CVE was published.";
 
   const pubLine = vuln.published ? `\n**CVE published:** ${vuln.published}` : "";
+  const sourceLabel = MATCH_SOURCE_LABELS[matchSource] || matchSource;
+  const labelList = appliedLabels.map((l) => `\`${l}\``).join(", ");
 
-  return `**Automated CVE match via [OSV.dev](https://osv.dev)**
+  return `**Automated CVE match via ${sourceLabel}**
 
 Matched advisory: [${advisoryId}](${advisoryUrl(advisoryId)})
 
 > ${summary}
 ${pubLine}${leadLine}
 
-This issue has been auto-labelled \`true-positive\` and \`cve:${advisoryId}\`.`;
+This issue has been auto-labelled ${labelList}.`;
 }
 
 async function addLabels(issueNumber, labels) {
@@ -194,7 +206,10 @@ async function main() {
 
     try {
       await addLabels(issue.number, labels);
-      await addComment(issue.number, buildComment(issue, parsed, vuln, advisoryId));
+      await addComment(
+        issue.number,
+        buildComment(issue, parsed, vuln, advisoryId, matchSource, labels)
+      );
       matched++;
     } catch (err) {
       console.error(`#${issue.number}: failed to update: ${err.message}`);

--- a/scripts/check-cves.mjs
+++ b/scripts/check-cves.mjs
@@ -15,7 +15,7 @@
 import { GITHUB_TOKEN, REPO_OWNER, REPO_NAME, REPO_TO_CPE } from "./lib/config.mjs";
 import { fetchAllIssues } from "./lib/github.mjs";
 import { parseIssueBody } from "./lib/parser.mjs";
-import { queryOsvByCommit, pickAdvisoryId, advisoryUrl, daysBetween } from "./lib/cve.mjs";
+import { queryOsvByCommit, pickBestVuln, pickAdvisoryId, advisoryUrl, daysBetween } from "./lib/cve.mjs";
 import { fetchNvdByCpe, pickBestNvdMatch } from "./lib/nvd.mjs";
 
 const GITHUB_API = "https://api.github.com";
@@ -175,8 +175,9 @@ async function main() {
 
     try {
       const vulns = await queryOsvByCommit(sha);
-      if (vulns.length > 0) {
-        vuln = vulns[0];
+      const picked = pickBestVuln(vulns);
+      if (picked) {
+        vuln = picked;
         advisoryId = pickAdvisoryId(vuln);
       }
     } catch (err) {

--- a/scripts/check-cves.mjs
+++ b/scripts/check-cves.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+// Checks untriaged vulnerability issues against OSV.dev for matching CVEs.
+// When a commit SHA from an issue matches a known advisory, the script:
+//   1. Adds the `true-positive` label
+//   2. Adds a `cve:<ID>` label (e.g. cve:CVE-2024-12345)
+//   3. Posts a comment summarising the match and the lead time
+//
+// Idempotent: skips issues that already carry any `cve:` label.
+
+import { GITHUB_TOKEN, REPO_OWNER, REPO_NAME, REPO_TO_CPE } from "./lib/config.mjs";
+import { fetchAllIssues } from "./lib/github.mjs";
+import { parseIssueBody } from "./lib/parser.mjs";
+import { queryOsvByCommit, pickAdvisoryId, advisoryUrl, daysBetween } from "./lib/cve.mjs";
+import { fetchNvdByCpe, pickBestNvdMatch } from "./lib/nvd.mjs";
+
+const GITHUB_API = "https://api.github.com";
+const TRUSTED_AUTHORS = ["github-actions[bot]"];
+
+async function githubRequest(path, options = {}) {
+  const response = await fetch(`${GITHUB_API}${path}`, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(options.body ? { "Content-Type": "application/json" } : {}),
+      ...(options.headers || {}),
+    },
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(
+      `GitHub API ${path} -> ${response.status} ${response.statusText}: ${text}`
+    );
+  }
+  return response.status === 204 ? null : response.json();
+}
+
+function labelNames(labels) {
+  return labels.map((l) => (typeof l === "string" ? l : l.name || ""));
+}
+
+function needsCveCheck(issue) {
+  const names = labelNames(issue.labels);
+  if (names.some((n) => n.startsWith("cve:"))) return false; // already checked
+  if (names.includes("false-positive")) return false; // respect manual call
+  return true;
+}
+
+function buildComment(issue, parsed, vuln, advisoryId) {
+  const leadBase = parsed.date || issue.created_at;
+  const lead = vuln.published ? daysBetween(leadBase, vuln.published) : null;
+  const summary = vuln.summary || vuln.details?.split("\n")[0] || "(no summary provided)";
+
+  const leadLine =
+    lead === null
+      ? ""
+      : lead > 0
+        ? `\n\n**Lead time:** Patch landed **${lead} day${lead === 1 ? "" : "s"}** before the CVE was published.`
+        : lead < 0
+          ? `\n\n**Lead time:** Patch landed ${Math.abs(lead)} day${lead === -1 ? "" : "s"} after the CVE was published.`
+          : "\n\n**Lead time:** Patch landed the same day the CVE was published.";
+
+  const pubLine = vuln.published ? `\n**CVE published:** ${vuln.published}` : "";
+
+  return `**Automated CVE match via [OSV.dev](https://osv.dev)**
+
+Matched advisory: [${advisoryId}](${advisoryUrl(advisoryId)})
+
+> ${summary}
+${pubLine}${leadLine}
+
+This issue has been auto-labelled \`true-positive\` and \`cve:${advisoryId}\`.`;
+}
+
+async function addLabels(issueNumber, labels) {
+  return githubRequest(
+    `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${issueNumber}/labels`,
+    { method: "POST", body: JSON.stringify({ labels }) }
+  );
+}
+
+async function addComment(issueNumber, body) {
+  return githubRequest(
+    `/repos/${REPO_OWNER}/${REPO_NAME}/issues/${issueNumber}/comments`,
+    { method: "POST", body: JSON.stringify({ body }) }
+  );
+}
+
+const NVD_WINDOW_DAYS_BEFORE = 14;
+const NVD_WINDOW_DAYS_AFTER = 120;
+const DAY_MS = 86400000;
+
+async function tryNvdFallback(issue, parsed) {
+  const cpes = REPO_TO_CPE[parsed.repository];
+  if (!cpes) return null;
+
+  const anchor = new Date(parsed.date || issue.created_at).getTime();
+  if (!Number.isFinite(anchor)) return null;
+  const start = new Date(anchor - NVD_WINDOW_DAYS_BEFORE * DAY_MS);
+  const end = new Date(anchor + NVD_WINDOW_DAYS_AFTER * DAY_MS);
+
+  const seen = new Set();
+  const candidates = [];
+  for (const cpe of cpes) {
+    try {
+      const cves = await fetchNvdByCpe(cpe, start, end);
+      for (const c of cves) {
+        if (seen.has(c.id)) continue;
+        seen.add(c.id);
+        candidates.push(c);
+      }
+    } catch (err) {
+      console.warn(`#${issue.number}: NVD query for ${cpe} failed: ${err.message}`);
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  const issueText = [parsed.vulnType, parsed.description, parsed.affectedCode]
+    .filter(Boolean)
+    .join(" ");
+  const best = pickBestNvdMatch(issueText, candidates);
+  if (!best) return null;
+
+  const cve = best.cve;
+  const description = (cve.descriptions || []).find((d) => d.lang === "en")?.value || "";
+  return {
+    advisoryId: cve.id,
+    vuln: {
+      id: cve.id,
+      summary: description,
+      published: cve.published ? new Date(cve.published).toISOString() : null,
+    },
+  };
+}
+
+async function main() {
+  if (!GITHUB_TOKEN) throw new Error("GITHUB_TOKEN is required.");
+
+  console.log("Fetching vulnerability issues...");
+  const allIssues = await fetchAllIssues();
+
+  const candidates = allIssues.filter((issue) => {
+    if (!TRUSTED_AUTHORS.includes(issue.user?.login)) return false;
+    return needsCveCheck(issue);
+  });
+
+  console.log(`${candidates.length} issues to check`);
+
+  let matched = 0;
+  for (const issue of candidates) {
+    const parsed = parseIssueBody(issue.body);
+    const sha = parsed.commitSha;
+    if (!sha) {
+      console.log(`#${issue.number}: no commit SHA in body, skipping`);
+      continue;
+    }
+
+    let vuln = null;
+    let advisoryId = null;
+    let matchSource = "osv-commit";
+
+    try {
+      const vulns = await queryOsvByCommit(sha);
+      if (vulns.length > 0) {
+        vuln = vulns[0];
+        advisoryId = pickAdvisoryId(vuln);
+      }
+    } catch (err) {
+      console.warn(`#${issue.number}: OSV query failed: ${err.message}`);
+    }
+
+    if (!vuln) {
+      const nvdMatch = await tryNvdFallback(issue, parsed);
+      if (nvdMatch) {
+        vuln = nvdMatch.vuln;
+        advisoryId = nvdMatch.advisoryId;
+        matchSource = "nvd-cpe";
+      }
+    }
+
+    if (!vuln) {
+      console.log(`#${issue.number}: no match for ${sha.slice(0, 10)}`);
+      continue;
+    }
+
+    console.log(`#${issue.number}: matched ${advisoryId} (${matchSource})`);
+
+    const labels = ["true-positive", `cve:${advisoryId}`];
+    if (vuln.published) {
+      labels.push(`cve-published:${vuln.published.slice(0, 10)}`);
+    }
+
+    try {
+      await addLabels(issue.number, labels);
+      await addComment(issue.number, buildComment(issue, parsed, vuln, advisoryId));
+      matched++;
+    } catch (err) {
+      console.error(`#${issue.number}: failed to update: ${err.message}`);
+    }
+  }
+
+  console.log(`Done. ${matched} issues matched and updated.`);
+}
+
+main().catch((err) => {
+  console.error("CVE check failed:", err);
+  process.exit(1);
+});

--- a/scripts/lib/config.mjs
+++ b/scripts/lib/config.mjs
@@ -20,5 +20,13 @@ export const SITE_URL = `https://${REPO_OWNER}.github.io/${REPO_NAME}`;
 
 export const MONITORED_REPOS = reposJson.map((r) => `${r.owner}/${r.repo}`);
 
+// repo (owner/repo) -> array of CPE 2.3 product prefixes for NVD lookup.
+// Configured per-repo in repos.json. Empty for repos that don't set `cpes`.
+export const REPO_TO_CPE = Object.fromEntries(
+  reposJson
+    .filter((r) => Array.isArray(r.cpes) && r.cpes.length > 0)
+    .map((r) => [`${r.owner}/${r.repo}`, r.cpes])
+);
+
 // Only process issues created by these GitHub usernames
 export const TRUSTED_ISSUE_AUTHORS = ["github-actions[bot]"];

--- a/scripts/lib/cve.mjs
+++ b/scripts/lib/cve.mjs
@@ -20,6 +20,19 @@ export async function queryOsvByCommit(commitSha) {
   return data.vulns || [];
 }
 
+function hasCveId(vuln) {
+  if (vuln.id?.startsWith("CVE-")) return true;
+  return (vuln.aliases || []).some((a) => a.startsWith("CVE-"));
+}
+
+// Among a list of OSV vuln records (e.g. multiple advisories matching one
+// commit), prefer the first one that carries a CVE identifier so callers can
+// surface a CVE ID rather than a GHSA when both are available.
+export function pickBestVuln(vulns) {
+  if (!vulns || vulns.length === 0) return null;
+  return vulns.find(hasCveId) || vulns[0];
+}
+
 // Pick the most useful identifier from an OSV record:
 // prefer a CVE alias, else use the OSV id (e.g. GHSA-xxxx).
 export function pickAdvisoryId(vuln) {

--- a/scripts/lib/cve.mjs
+++ b/scripts/lib/cve.mjs
@@ -1,0 +1,49 @@
+// OSV.dev lookup for CVE/advisory matches against a commit SHA.
+// Docs: https://google.github.io/osv.dev/post-v1-query/
+
+const OSV_QUERY_URL = "https://api.osv.dev/v1/query";
+
+export async function queryOsvByCommit(commitSha) {
+  if (!commitSha) return [];
+
+  const response = await fetch(OSV_QUERY_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ commit: commitSha }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`OSV API error: ${response.status} ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return data.vulns || [];
+}
+
+// Pick the most useful identifier from an OSV record:
+// prefer a CVE alias, else use the OSV id (e.g. GHSA-xxxx).
+export function pickAdvisoryId(vuln) {
+  const aliases = vuln.aliases || [];
+  const cve = aliases.find((a) => a.startsWith("CVE-"));
+  if (cve) return cve;
+  if (vuln.id?.startsWith("CVE-")) return vuln.id;
+  return vuln.id;
+}
+
+export function advisoryUrl(id) {
+  if (id?.startsWith("CVE-")) {
+    return `https://nvd.nist.gov/vuln/detail/${id}`;
+  }
+  if (id?.startsWith("GHSA-")) {
+    return `https://github.com/advisories/${id}`;
+  }
+  return `https://osv.dev/vulnerability/${id}`;
+}
+
+// Returns whole days between two ISO timestamps (b - a). Positive = b is later.
+export function daysBetween(aIso, bIso) {
+  const a = new Date(aIso).getTime();
+  const b = new Date(bIso).getTime();
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+  return Math.round((b - a) / 86400000);
+}

--- a/scripts/lib/cve.mjs
+++ b/scripts/lib/cve.mjs
@@ -26,7 +26,6 @@ export function pickAdvisoryId(vuln) {
   const aliases = vuln.aliases || [];
   const cve = aliases.find((a) => a.startsWith("CVE-"));
   if (cve) return cve;
-  if (vuln.id?.startsWith("CVE-")) return vuln.id;
   return vuln.id;
 }
 

--- a/scripts/lib/html.mjs
+++ b/scripts/lib/html.mjs
@@ -1,12 +1,27 @@
 import { SITE_TITLE, SITE_DESCRIPTION, GITHUB_REPOSITORY, MONITORED_REPOS } from "./config.mjs";
 import { escapeHtml, toHumanDate, repoToFeedFilename, sanitizeUrl } from "./utils.mjs";
-import { severityFromLabels, verificationStatus, severityColor, severityEmoji } from "./parser.mjs";
+import { severityFromLabels, verificationStatus, severityColor, severityEmoji, cveFromLabels } from "./parser.mjs";
+import { advisoryUrl, daysBetween } from "./cve.mjs";
 
-function generateVulnCard(issue, parsed, severity, status) {
+function generateVulnCard(issue, parsed, severity, status, cve) {
   const isFalsePositive = status === "false-positive";
   const isConfirmed = status === "confirmed";
   const isClosed = issue.state === "closed";
   const isCritical = severity.toLowerCase() === "critical";
+
+  const leadBase = parsed.date || issue.created_at;
+  const lead = cve?.published ? daysBetween(leadBase, cve.published) : null;
+  const cveBadge = cve
+    ? ` <a class="cve-badge" href="${escapeHtml(sanitizeUrl(advisoryUrl(cve.id)))}" title="View advisory">${escapeHtml(cve.id)}</a>`
+    : "";
+  const leadLine =
+    lead !== null && lead > 0
+      ? `<p class="lead-time">&#x1F4C8; Patch landed <strong>${lead}</strong> day${lead === 1 ? "" : "s"} before CVE published</p>`
+      : lead !== null && lead < 0
+        ? `<p class="lead-time late">Patch landed ${Math.abs(lead)} day${lead === -1 ? "" : "s"} after CVE published</p>`
+        : lead === 0
+          ? `<p class="lead-time">Patch landed same day as CVE</p>`
+          : "";
 
   const cardClass = isFalsePositive ? "vuln-card false-positive" : "vuln-card";
 
@@ -35,10 +50,11 @@ function generateVulnCard(issue, parsed, severity, status) {
   <h3>
     ${severityEmoji(severity)}
     <span class="severity-badge" style="background:${severityColor(severity)}">${escapeHtml(severity.toUpperCase())}</span>
-    ${statusBadge}${patchedBadge}
+    ${statusBadge}${patchedBadge}${cveBadge}
     ${escapeHtml(parsed.vulnType || "Security Patch")}
   </h3>
   <p class="dateline">${dateStr} &mdash; ${repoStr}</p>
+  ${leadLine}
   ${parsed.commitSha ? `<p><strong>Commit:</strong> <a href="${escapeHtml(sanitizeUrl(parsed.commitUrl))}">${escapeHtml(parsed.commitSha)}</a></p>` : ""}
   ${parsed.author ? `<p><strong>Author:</strong> ${escapeHtml(parsed.author)}</p>` : ""}
   <p class="description">${escapeHtml(parsed.description || "No description available.")}</p>
@@ -64,6 +80,7 @@ export function generateHTML(issues, parsedIssues) {
     parsed: parsedIssues[i],
     severity: severityFromLabels(issue.labels),
     status: verificationStatus(issue.labels),
+    cve: cveFromLabels(issue.labels),
   }));
 
   const mainItems = classified.filter((c) => c.status !== "false-positive");
@@ -83,6 +100,23 @@ export function generateHTML(issues, parsedIssues) {
     }
   }
 
+  // CVE / lead-time aggregates (measured from commit landing to CVE publication)
+  const cveMatches = classified.filter((c) => c.cve);
+  const leadTimes = cveMatches
+    .map((c) =>
+      c.cve.published
+        ? daysBetween(c.parsed.date || c.issue.created_at, c.cve.published)
+        : null
+    )
+    .filter((d) => d !== null);
+  const cveCount = cveMatches.length;
+  const earlyCount = leadTimes.filter((d) => d > 0).length;
+  const maxLead = leadTimes.length > 0 ? Math.max(...leadTimes) : null;
+  const avgLead =
+    leadTimes.length > 0
+      ? Math.round(leadTimes.reduce((a, b) => a + b, 0) / leadTimes.length)
+      : null;
+
   // Visitor counter: deterministic pseudo-random
   const day = Math.floor(Date.now() / 86400000);
   const visitorCount = 1337 + total * 42 + (day % 100);
@@ -91,7 +125,7 @@ export function generateHTML(issues, parsedIssues) {
     mainItems.length > 0
       ? mainItems
           .map((c) =>
-            generateVulnCard(c.issue, c.parsed, c.severity, c.status)
+            generateVulnCard(c.issue, c.parsed, c.severity, c.status, c.cve)
           )
           .join("\n")
       : `<div class="vuln-card" style="text-align:center; border-left-color:#8a8578;">
@@ -105,7 +139,7 @@ export function generateHTML(issues, parsedIssues) {
       ? `<details class="corrections">
   <summary>&#x274C; Corrections &amp; Retractions (${fpCount})</summary>
   ${falsePositives
-    .map((c) => generateVulnCard(c.issue, c.parsed, c.severity, c.status))
+    .map((c) => generateVulnCard(c.issue, c.parsed, c.severity, c.status, c.cve))
     .join("\n")}
 </details>`
       : "";
@@ -437,6 +471,58 @@ export function generateHTML(issues, parsedIssues) {
       background: #1a4a7a;
       color: #fff;
     }
+    .cve-badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 3px;
+      font-size: 0.7em;
+      font-weight: bold;
+      font-family: 'Courier New', Courier, monospace;
+      letter-spacing: 0.03em;
+      background: #2a2a28;
+      color: #f5f0e8 !important;
+      text-decoration: none;
+    }
+    .cve-badge:hover {
+      background: #c41e1e;
+    }
+    .lead-time {
+      font-family: 'Courier New', Courier, monospace;
+      font-size: 0.85em;
+      color: #2a7a2a;
+      background: #e8f0e0;
+      padding: 4px 10px;
+      border-left: 3px solid #2a7a2a;
+      margin: 0.4em 0 !important;
+      display: inline-block;
+    }
+    .lead-time.late {
+      color: #8a8578;
+      background: #f0ede6;
+      border-left-color: #8a8578;
+    }
+    .cve-row {
+      display: flex;
+      justify-content: center;
+      gap: 1.8em;
+      flex-wrap: wrap;
+      margin-top: 1em;
+      padding-top: 0.8em;
+      border-top: 1px solid #ddd;
+      text-align: center;
+    }
+    .cve-stat-num {
+      font-family: 'Courier New', Courier, monospace;
+      font-weight: bold;
+      font-size: 1.1em;
+      color: #c41e1e;
+    }
+    .cve-stat-label {
+      font-size: 0.75em;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #8a8578;
+    }
 
     /* Code headings & blocks */
     .code-heading {
@@ -586,6 +672,16 @@ export function generateHTML(issues, parsedIssues) {
     </div>
   </div>
   ${severityStats ? `<div class="severity-row">${severityStats}</div>` : ""}
+  ${
+    cveCount > 0
+      ? `<div class="cve-row">
+    <div class="cve-stat"><span class="cve-stat-num">${cveCount}</span> <span class="cve-stat-label">CVE matched</span></div>
+    <div class="cve-stat"><span class="cve-stat-num">${earlyCount}</span> <span class="cve-stat-label">found before CVE</span></div>
+    ${avgLead !== null ? `<div class="cve-stat"><span class="cve-stat-num">${avgLead}</span> <span class="cve-stat-label">avg lead (days)</span></div>` : ""}
+    ${maxLead !== null ? `<div class="cve-stat"><span class="cve-stat-num">${maxLead}</span> <span class="cve-stat-label">max lead (days)</span></div>` : ""}
+  </div>`
+      : ""
+  }
 </section>
 
 <hr class="thick-rule">

--- a/scripts/lib/nvd.mjs
+++ b/scripts/lib/nvd.mjs
@@ -21,11 +21,12 @@ function formatDate(d) {
   return new Date(d).toISOString().replace("Z", "");
 }
 
-export async function fetchNvdByCpe(cpe, pubStart, pubEnd) {
+async function fetchNvdPage(cpe, pubStart, pubEnd, startIndex) {
   const params = new URLSearchParams({
     virtualMatchString: cpe,
     pubStartDate: formatDate(pubStart),
     pubEndDate: formatDate(pubEnd),
+    startIndex: String(startIndex),
   });
   const headers = { Accept: "application/json" };
   if (NVD_API_KEY) headers.apiKey = NVD_API_KEY;
@@ -35,8 +36,24 @@ export async function fetchNvdByCpe(cpe, pubStart, pubEnd) {
   if (!response.ok) {
     throw new Error(`NVD API error: ${response.status} ${response.statusText}`);
   }
-  const data = await response.json();
-  return (data.vulnerabilities || []).map((v) => v.cve);
+  return response.json();
+}
+
+export async function fetchNvdByCpe(cpe, pubStart, pubEnd) {
+  const out = [];
+  let startIndex = 0;
+  // Safety cap: NVD page is at most 2000; 20 pages = 40k CVEs is plenty for any
+  // single CPE/window we'd actually query. Prevents runaway loops on bad input.
+  for (let pages = 0; pages < 20; pages++) {
+    const data = await fetchNvdPage(cpe, pubStart, pubEnd, startIndex);
+    for (const v of data.vulnerabilities || []) out.push(v.cve);
+
+    const total = data.totalResults ?? 0;
+    const perPage = data.resultsPerPage ?? 0;
+    startIndex += perPage;
+    if (perPage === 0 || startIndex >= total) break;
+  }
+  return out;
 }
 
 const STOPWORDS = new Set([

--- a/scripts/lib/nvd.mjs
+++ b/scripts/lib/nvd.mjs
@@ -1,0 +1,95 @@
+// NVD CVE 2.0 API fallback for matching issues to CVEs when OSV has no commit ref.
+// Docs: https://nvd.nist.gov/developers/vulnerabilities
+
+const NVD_API = "https://services.nvd.nist.gov/rest/json/cves/2.0";
+
+function formatDate(d) {
+  // NVD wants ISO-extended with millis, no Z (uses local "UTC" implicitly per docs).
+  return new Date(d).toISOString().replace("Z", "");
+}
+
+export async function fetchNvdByCpe(cpe, pubStart, pubEnd) {
+  const params = new URLSearchParams({
+    virtualMatchString: cpe,
+    pubStartDate: formatDate(pubStart),
+    pubEndDate: formatDate(pubEnd),
+  });
+  const response = await fetch(`${NVD_API}?${params.toString()}`, {
+    headers: { Accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`NVD API error: ${response.status} ${response.statusText}`);
+  }
+  const data = await response.json();
+  return (data.vulnerabilities || []).map((v) => v.cve);
+}
+
+const STOPWORDS = new Set([
+  "a", "an", "the", "is", "are", "was", "were", "be", "been", "being",
+  "to", "in", "of", "and", "or", "for", "with", "by", "from", "on", "at",
+  "as", "if", "it", "that", "this", "these", "those",
+  "can", "may", "might", "could", "would", "should", "must",
+  "have", "has", "had", "will", "shall", "do", "does", "did",
+  "not", "no", "yes", "any", "all", "some", "many", "much",
+  "use", "used", "using", "via", "through", "during",
+  "allow", "allows", "allowing", "allowed",
+  "vulnerability", "vulnerable", "issue", "issues",
+  "attacker", "attackers", "user", "users",
+  "affect", "affects", "affected", "affecting",
+  "result", "results", "resulted", "resulting",
+  "cause", "causes", "caused", "causing",
+  "when", "where", "while", "before", "after",
+  "which", "what", "who", "whom", "whose",
+  "also", "such", "than", "then", "thus",
+  "due", "into", "onto", "out", "over", "under",
+  "other", "others", "more", "less", "most", "least",
+]);
+
+function tokenize(text) {
+  if (!text) return new Set();
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9_]+/g, " ")
+      .split(/\s+/)
+      .filter((w) => w.length >= 4 && !STOPWORDS.has(w))
+  );
+}
+
+function sharedTokens(a, b) {
+  let shared = 0;
+  const matched = [];
+  for (const w of a) {
+    if (b.has(w)) {
+      shared++;
+      matched.push(w);
+    }
+  }
+  return { count: shared, tokens: matched };
+}
+
+function cveDescription(cve) {
+  const en = (cve.descriptions || []).find((d) => d.lang === "en");
+  return en?.value || "";
+}
+
+// Score candidates against issue text and return best match (or null if too weak).
+// Match policy: best must have >= MIN_SHARED tokens AND be >= MARGIN_RATIO * second-best.
+export function pickBestNvdMatch(issueText, candidates, { minShared = 3, marginRatio = 1.5 } = {}) {
+  if (candidates.length === 0) return null;
+  const issueTokens = tokenize(issueText);
+  if (issueTokens.size === 0) return null;
+
+  const scored = candidates
+    .map((cve) => {
+      const { count, tokens } = sharedTokens(issueTokens, tokenize(cveDescription(cve)));
+      return { cve, score: count, tokens };
+    })
+    .sort((a, b) => b.score - a.score);
+
+  const best = scored[0];
+  const second = scored[1];
+  if (best.score < minShared) return null;
+  if (second && second.score > 0 && best.score < marginRatio * second.score) return null;
+  return best;
+}

--- a/scripts/lib/nvd.mjs
+++ b/scripts/lib/nvd.mjs
@@ -3,6 +3,19 @@
 
 const NVD_API = "https://services.nvd.nist.gov/rest/json/cves/2.0";
 
+// NVD rate limits: 5 req / 30s rolling without key, 50 / 30s with key.
+// Leave headroom so transient delays don't push us over the window.
+const NVD_API_KEY = process.env.NVD_API_KEY || "";
+const MIN_INTERVAL_MS = NVD_API_KEY ? 700 : 6500;
+
+let lastRequestAt = 0;
+
+async function throttle() {
+  const wait = MIN_INTERVAL_MS - (Date.now() - lastRequestAt);
+  if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+  lastRequestAt = Date.now();
+}
+
 function formatDate(d) {
   // NVD wants ISO-extended with millis, no Z (uses local "UTC" implicitly per docs).
   return new Date(d).toISOString().replace("Z", "");
@@ -14,9 +27,11 @@ export async function fetchNvdByCpe(cpe, pubStart, pubEnd) {
     pubStartDate: formatDate(pubStart),
     pubEndDate: formatDate(pubEnd),
   });
-  const response = await fetch(`${NVD_API}?${params.toString()}`, {
-    headers: { Accept: "application/json" },
-  });
+  const headers = { Accept: "application/json" };
+  if (NVD_API_KEY) headers.apiKey = NVD_API_KEY;
+
+  await throttle();
+  const response = await fetch(`${NVD_API}?${params.toString()}`, { headers });
   if (!response.ok) {
     throw new Error(`NVD API error: ${response.status} ${response.statusText}`);
   }

--- a/scripts/lib/parser.mjs
+++ b/scripts/lib/parser.mjs
@@ -1,5 +1,14 @@
-// Parses the structured markdown created by vulnerability-spoiler-alert-action
-
+// Parses the structured markdown created by vulnerability-spoiler-alert-action.
+//
+// Returns an object with: repository, commitSha, commitUrl, author, date,
+// vulnType, severity, description, affectedCode, proofOfConcept. All values
+// are strings or null.
+//
+// Note on `date`: this is the commit date from the issue's **Date:** line,
+// normalized to an ISO-8601 string (e.g. "2026-03-16T16:13:03.000Z") when the
+// raw value parses, or null otherwise. Callers can pass it directly to
+// `new Date(...)`; callers that need the raw body text should read the body
+// themselves.
 export function parseIssueBody(body) {
   if (!body) return {};
 

--- a/scripts/lib/parser.mjs
+++ b/scripts/lib/parser.mjs
@@ -68,6 +68,17 @@ export function verificationStatus(labels) {
   return "unverified";
 }
 
+export function cveFromLabels(labels) {
+  const names = labels.map((l) => (typeof l === "string" ? l : l.name || ""));
+  const idLabel = names.find((n) => n.startsWith("cve:"));
+  const pubLabel = names.find((n) => n.startsWith("cve-published:"));
+  if (!idLabel) return null;
+  return {
+    id: idLabel.slice("cve:".length),
+    published: pubLabel ? pubLabel.slice("cve-published:".length) : null,
+  };
+}
+
 export function severityColor(severity) {
   const colors = {
     critical: "#c41e1e",

--- a/scripts/lib/parser.mjs
+++ b/scripts/lib/parser.mjs
@@ -16,7 +16,14 @@ export function parseIssueBody(body) {
   const author = authorMatch ? authorMatch[1].trim() : null;
 
   const dateMatch = body.match(/\*\*Date:\*\*\s*(.+)/);
-  const date = dateMatch ? dateMatch[1].trim() : null;
+  const rawDate = dateMatch ? dateMatch[1].trim() : null;
+  // Normalize to ISO-8601 if the raw value parses; otherwise drop it so callers
+  // can fall back to issue.created_at instead of getting NaN from new Date(...).
+  let date = null;
+  if (rawDate) {
+    const ts = new Date(rawDate).getTime();
+    if (Number.isFinite(ts)) date = new Date(ts).toISOString();
+  }
 
   const vulnTypeMatch = body.match(/\*\*Vulnerability Type:\*\*\s*(.+)/);
   const vulnType = vulnTypeMatch ? vulnTypeMatch[1].trim() : null;

--- a/scripts/lib/rss.mjs
+++ b/scripts/lib/rss.mjs
@@ -22,10 +22,11 @@ export function generateRSS(issues, parsedIssues, { title, description, feedPath
       const pubDate = toRFC822(issue.created_at);
       const cvePrefix = cve ? `[${cve.id}] ` : "";
       const title = `${cvePrefix}[${severity.toUpperCase()}] ${parsed.vulnType || "Vulnerability"} in ${parsed.repository || "Unknown"}`;
-      const lead = cve?.published ? daysBetween(issue.created_at, cve.published) : null;
+      const leadBase = parsed.date || issue.created_at;
+      const lead = cve?.published ? daysBetween(leadBase, cve.published) : null;
       const leadNote =
         lead !== null && lead > 0
-          ? `\n\nFound ${lead} day${lead === 1 ? "" : "s"} before ${cve.id} was published.`
+          ? `\n\nPatch landed ${lead} day${lead === 1 ? "" : "s"} before ${cve.id} was published.`
           : "";
       const desc = (parsed.description || issue.title) + leadNote;
 

--- a/scripts/lib/rss.mjs
+++ b/scripts/lib/rss.mjs
@@ -1,6 +1,7 @@
 import { SITE_TITLE, SITE_DESCRIPTION, SITE_URL } from "./config.mjs";
 import { escapeXml, toRFC822 } from "./utils.mjs";
-import { severityFromLabels, verificationStatus } from "./parser.mjs";
+import { severityFromLabels, verificationStatus, cveFromLabels } from "./parser.mjs";
+import { daysBetween } from "./cve.mjs";
 
 export function generateRSS(issues, parsedIssues, { title, description, feedPath, repoFilter } = {}) {
   const feedTitle = title || SITE_TITLE;
@@ -17,9 +18,16 @@ export function generateRSS(issues, parsedIssues, { title, description, feedPath
     .map(({ issue, parsed }) => {
       const severity = severityFromLabels(issue.labels);
       const status = verificationStatus(issue.labels);
+      const cve = cveFromLabels(issue.labels);
       const pubDate = toRFC822(issue.created_at);
-      const title = `[${severity.toUpperCase()}] ${parsed.vulnType || "Vulnerability"} in ${parsed.repository || "Unknown"}`;
-      const desc = parsed.description || issue.title;
+      const cvePrefix = cve ? `[${cve.id}] ` : "";
+      const title = `${cvePrefix}[${severity.toUpperCase()}] ${parsed.vulnType || "Vulnerability"} in ${parsed.repository || "Unknown"}`;
+      const lead = cve?.published ? daysBetween(issue.created_at, cve.published) : null;
+      const leadNote =
+        lead !== null && lead > 0
+          ? `\n\nFound ${lead} day${lead === 1 ? "" : "s"} before ${cve.id} was published.`
+          : "";
+      const desc = (parsed.description || issue.title) + leadNote;
 
       return `    <item>
       <title>${escapeXml(title)}</title>
@@ -29,6 +37,7 @@ export function generateRSS(issues, parsedIssues, { title, description, feedPath
       <description>${escapeXml(desc)}</description>
       <category>${escapeXml(severity)}</category>
       <category>${escapeXml(status)}</category>
+      ${cve ? `<category>${escapeXml(cve.id)}</category>` : ""}
     </item>`;
     })
     .join("\n");


### PR DESCRIPTION
This pull request introduces an automated workflow and supporting scripts to match untriaged vulnerability issues to known CVEs using OSV.dev and NVD, auto-labeling issues and surfacing CVE information in the web UI. The changes include a new scheduled GitHub Actions workflow, enhancements to the data model for repositories, new and updated scripts for CVE matching, and improvements to the HTML output to display CVE badges, lead times, and aggregate statistics.

**Automated CVE Matching and Labeling:**

- Added a scheduled GitHub Actions workflow (`.github/workflows/cve-check.yml`) that runs every 6 hours to match untriaged issues to CVEs using the new `scripts/check-cves.mjs` script. This script queries OSV.dev by commit SHA, falls back to NVD by CPE if needed, and auto-labels issues with `true-positive`, `cve:<ID>`, and `cve-published:<date>` labels, also posting a summary comment. [[1]](diffhunk://#diff-1458aeac2def22fc78040e52da793d42abb622c419b47466e3ce6596599fd8f9R1-R30) [[2]](diffhunk://#diff-d9cae1c7b6215b9093e5fd2ab74615f7247c15ef24b31a2020facd73611b1d3aR1-R210) [[3]](diffhunk://#diff-d73d773159c1d72bf926d926d99eeff14c4723151f29dce1549ab4ab23db63fbR1-R49) [[4]](diffhunk://#diff-f68a152b8810dcdaac1e0b507951bcc6e5b65cd025c743c4d517f03e3cdb604bR1-R95)

- Introduced new utility modules for querying OSV.dev (`scripts/lib/cve.mjs`) and NVD (`scripts/lib/nvd.mjs`), including logic for advisory ID selection, date calculations, and best-match scoring based on token overlap. [[1]](diffhunk://#diff-d73d773159c1d72bf926d926d99eeff14c4723151f29dce1549ab4ab23db63fbR1-R49) [[2]](diffhunk://#diff-f68a152b8810dcdaac1e0b507951bcc6e5b65cd025c743c4d517f03e3cdb604bR1-R95)

**Repository Data Model Enhancements:**

- Updated `repos.json` to include a `cpes` field for each monitored repository, mapping to relevant CPE 2.3 product strings for NVD lookups.
- Added logic in `scripts/lib/config.mjs` to map repositories to their CPEs for use in the matching workflow.

**HTML Output and UI Improvements:**

- Enhanced the HTML generation (`scripts/lib/html.mjs`) to:
  - Display CVE badges with links to advisories and lead-time indicators (days between patch and CVE publication) on each vulnerability card. [[1]](diffhunk://#diff-55fc036d2dbbd1e6c16fcc9ff0244cdaf3b8dc9288275cc2e4ce8b40394b06d6L3-R25) [[2]](diffhunk://#diff-55fc036d2dbbd1e6c16fcc9ff0244cdaf3b8dc9288275cc2e4ce8b40394b06d6L38-R57)
  - Show aggregate statistics for CVE matches and lead times in a summary row. [[1]](diffhunk://#diff-55fc036d2dbbd1e6c16fcc9ff0244cdaf3b8dc9288275cc2e4ce8b40394b06d6R103-R119) [[2]](diffhunk://#diff-55fc036d2dbbd1e6c16fcc9ff0244cdaf3b8dc9288275cc2e4ce8b40394b06d6R474-R525) [[3]](diffhunk://#diff-55fc036d2dbbd1e6c16fcc9ff0244cdaf3b8dc9288275cc2e4ce8b40394b06d6R675-R684)
  - Extract CVE info from labels for display using a new `cveFromLabels` helper in the parser. [[1]](diffhunk://#diff-b2c7e5a561dbf8b283adb79603e7607eab0d9c69b46808f2ce554003053111f5R71-R81) [[2]](diffhunk://#diff-55fc036d2dbbd1e6c16fcc9ff0244cdaf3b8dc9288275cc2e4ce8b40394b06d6R83)

**Parser and Utility Enhancements:**

- Added `cveFromLabels` to the parser module to extract CVE ID and publication date from issue labels for UI display.

These changes automate the process of matching issues to CVEs, improve the visibility of CVE-related information in the UI, and lay the groundwork for more robust vulnerability tracking and reporting.